### PR TITLE
chore(package.json): bump rxjs to rc4, remove chai types

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,11 @@
     "@angular/platform-browser-dynamic": "~2.2.1",
     "@angular/router": "~3.2.1",
     "core-js": "^2.4.1",
-    "rxjs": "5.0.0-rc.3",
+    "rxjs": "5.0.0-rc.4",
     "ts-helpers": "^1.1.2",
     "zone.js": "^0.6.26"
   },
   "devDependencies": {
-    "@types/chai": "^3.4.34",
     "@types/jasmine": "^2.5.38",
     "@types/node": "^6.0.48",
     "angular-cli": "1.0.0-beta.20-4",


### PR DESCRIPTION
rc4 fixed the https://github.com/ReactiveX/rxjs/issues/2112 so the chai types are no longer needed.

rc4 had other very minor changes: https://github.com/ReactiveX/rxjs/blob/master/CHANGELOG.md#500-rc4-2016-11-19

### Bug Fixes

* **partition:** handles `thisArg` as expected ([#2138](https://github.com/ReactiveX/RxJS/issues/2138)) ([6cf7296](https://github.com/ReactiveX/RxJS/commit/6cf7296))
* **timeout:** throw traceable TimeoutError ([#2132](https://github.com/ReactiveX/RxJS/issues/2132)) ([9ebc46b](https://github.com/ReactiveX/RxJS/commit/9ebc46b))
